### PR TITLE
Add option to use default auth with Crane image resolver

### DIFF
--- a/pkg/imageresolver/imageresolver.go
+++ b/pkg/imageresolver/imageresolver.go
@@ -80,6 +80,11 @@ func GetResolver(resolver ResolverOption, args map[string]string) (ImageResolver
 		username, ok := args["username"]
 		if ok {
 			opts = append(opts, WithUserPassAuth(username, args["password"]))
+		} else {
+			usedefault := args["usedefault"]
+			if usedefault == "true" {
+				opts = append(opts, WithDefaultKeychain())
+			}
 		}
 
 		return NewCraneResolver(opts...), nil

--- a/pkg/imageresolver/imageresolver_test.go
+++ b/pkg/imageresolver/imageresolver_test.go
@@ -10,3 +10,17 @@ var _ = Describe("getName func", func() {
 		Expect(getName("localhost:5005/controller:v0.0.1")).To(Equal("localhost:5005/controller"))
 	})
 })
+
+var _ = Describe("GetResolver", func() {
+	Describe("CraneAuth", func() {
+		It("returns a Crane resolver with the default options", func() {
+			args := make(map[string]string)
+			args["usedefault"] = "true"
+
+			resolver, err := GetResolver(ResolverCrane, args)
+			Expect(err).To(BeNil())
+			Expect(resolver).NotTo(BeNil())
+			Expect(resolver.(CraneResolver).useDefault).To(BeTrue())
+		})
+	})
+})


### PR DESCRIPTION
Kinda weird that this forces no-auth as the default, but I've left that as the default option, and added the option to turn on Crane's default auth (which uses local auth, i.e. if you've already `docker login`'d in your terminal, it will use that token or whatever).

Fixes [#6027](https://github.com/operator-framework/operator-sdk/issues/6027) and [#6095](https://github.com/operator-framework/operator-sdk/issues/6095) in Operator SDK.