### PR TITLE
Add insecure option for Crane imageresolver

### DIFF
--- a/pkg/imageresolver/imageresolver.go
+++ b/pkg/imageresolver/imageresolver.go
@@ -86,6 +86,10 @@ func GetResolver(resolver ResolverOption, args map[string]string) (ImageResolver
 				opts = append(opts, WithDefaultKeychain())
 			}
 		}
+		insecure := args["insecure"]
+		if insecure == "true" {
+			opts = append(opts, Insecure())
+		}
 
 		return NewCraneResolver(opts...), nil
 	default:

--- a/pkg/imageresolver/imageresolver_test.go
+++ b/pkg/imageresolver/imageresolver_test.go
@@ -21,6 +21,23 @@ var _ = Describe("GetResolver", func() {
 			Expect(err).To(BeNil())
 			Expect(resolver).NotTo(BeNil())
 			Expect(resolver.(CraneResolver).useDefault).To(BeTrue())
+			Expect(resolver.(CraneResolver).insecure).To(BeFalse())
+		})
+	})
+})
+
+var _ = Describe("GetResolver", func() {
+	Describe("CraneAuth", func() {
+		It("returns a Crane resolver with the insecure option", func() {
+			args := make(map[string]string)
+			args["usedefault"] = "true"
+			args["insecure"] = "true"
+
+			resolver, err := GetResolver(ResolverCrane, args)
+			Expect(err).To(BeNil())
+			Expect(resolver).NotTo(BeNil())
+			Expect(resolver.(CraneResolver).useDefault).To(BeTrue())
+			Expect(resolver.(CraneResolver).insecure).To(BeTrue())
 		})
 	})
 })


### PR DESCRIPTION
The intent is to use this with operator-sdk to support a potential command like:

operator-sdk generate bundle --use-image-digests --insecure

This would allow us to build bundles (with digests) in environments without secure registries.