### PR TITLE
Update and cleanup to use modern Go language features

### DIFF
--- a/cmd/pinning/pinning_test.go
+++ b/cmd/pinning/pinning_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"html/template"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -35,15 +34,15 @@ var _ = Describe("pinning", func() {
 		// 	Delims("{", "}").Parse(CSV_TEMPLATE_WITH_RELATED_IMAGES))
 		resolved = template.Must(template.New("resolved").Parse(CSV_RESOLVED_TEMPLATE))
 
-		dir, err := ioutil.TempDir("", "script")
+		dir, err := os.MkdirTemp("", "script")
 		Expect(err).To(Succeed())
-		manifestDir, err = ioutil.TempDir("", "pinning_test_")
+		manifestDir, err = os.MkdirTemp("", "pinning_test_")
 		Expect(err).To(Succeed())
 		csvFilePath = filepath.Join(manifestDir, "clusterserviceversion.yaml")
 
 		resolverScript := filepath.Join(dir, "resolver.sh")
 
-		err = ioutil.WriteFile(resolverScript, []byte(`#!/bin/bash
+		err = os.WriteFile(resolverScript, []byte(`#!/bin/bash
 if [ "$1" == "registry.example.com/eggs:9.8" ]; then
    echo -n "2"
    exit 0
@@ -190,7 +189,7 @@ exit 1
 			err := replace(manifestDir, bytes.NewReader(resolveData))
 			Expect(err).To(Succeed())
 
-			fileData, err := ioutil.ReadFile(csvFilePath)
+			fileData, err := os.ReadFile(csvFilePath)
 			Expect(err).To(Succeed())
 
 			Expect(fileData).To(MatchUnorderedYAML(resolvedFile))
@@ -223,12 +222,12 @@ exit 1
 					},
 				})
 
-			extractFile, err = ioutil.TempFile(dir, "extract")
+			extractFile, err = os.CreateTemp(dir, "extract")
 			Expect(err).To(Succeed())
 			outputExtract = utils.NewOutputParam()
 			outputExtract.Name = extractFile.Name()
 
-			replaceFile, err = ioutil.TempFile(dir, "replace")
+			replaceFile, err = os.CreateTemp(dir, "replace")
 			Expect(err).To(Succeed())
 			outputReplace = utils.NewOutputParam()
 			outputReplace.Name = replaceFile.Name()

--- a/cmd/pinning/pinning_test.go
+++ b/cmd/pinning/pinning_test.go
@@ -11,8 +11,8 @@ import (
 	. "github.com/benjamintf1/unmarshalledmatchers"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"github.com/operator-framework/operator-manifest-tools/pkg/imageresolver"
 	"github.com/operator-framework/operator-manifest-tools/internal/utils"
+	"github.com/operator-framework/operator-manifest-tools/pkg/imageresolver"
 	"gopkg.in/yaml.v3"
 )
 
@@ -35,13 +35,15 @@ var _ = Describe("pinning", func() {
 		// 	Delims("{", "}").Parse(CSV_TEMPLATE_WITH_RELATED_IMAGES))
 		resolved = template.Must(template.New("resolved").Parse(CSV_RESOLVED_TEMPLATE))
 
-		dir, _ = ioutil.TempDir("", "script")
-		manifestDir, _ = ioutil.TempDir("", "pinning_test_")
+		dir, err := ioutil.TempDir("", "script")
+		Expect(err).To(Succeed())
+		manifestDir, err = ioutil.TempDir("", "pinning_test_")
+		Expect(err).To(Succeed())
 		csvFilePath = filepath.Join(manifestDir, "clusterserviceversion.yaml")
 
 		resolverScript := filepath.Join(dir, "resolver.sh")
 
-		ioutil.WriteFile(resolverScript, []byte(`#!/bin/bash
+		err = ioutil.WriteFile(resolverScript, []byte(`#!/bin/bash
 if [ "$1" == "registry.example.com/eggs:9.8" ]; then
    echo -n "2"
    exit 0
@@ -54,6 +56,7 @@ fi
 
 exit 1
 `), 0700)
+		Expect(err).To(Succeed())
 
 		resolver, _ = imageresolver.GetResolver(imageresolver.ResolverScript, map[string]string{
 			"path": resolverScript,
@@ -89,7 +92,7 @@ exit 1
 			extractData := bytes.Buffer{}
 			extract(manifestDir, &extractData)
 
-			extractJson := []interface{}{}
+			extractJson := []any{}
 
 			Expect(json.Unmarshal(extractData.Bytes(), &extractJson)).To(Succeed())
 			Expect(extractJson).To(HaveLen(2))
@@ -118,7 +121,7 @@ exit 1
 					},
 				})
 
-			extractData, _ = json.Marshal([]interface{}{
+			extractData, _ = json.Marshal([]any{
 				"registry.example.com/eggs:9.8",
 				"registry.example.com/maps/spam-operator:1.2",
 			})
@@ -129,11 +132,11 @@ exit 1
 			err := resolve(resolver, bytes.NewReader(extractData), &resolveData)
 			Expect(err).To(Succeed())
 
-			resolveJson := map[string]interface{}{}
+			resolveJson := map[string]any{}
 			Expect(json.Unmarshal(resolveData.Bytes(), &resolveJson)).To(Succeed())
 			Expect(resolveJson).To(HaveLen(2))
 			Expect(resolveJson).To(Equal(
-				map[string]interface{}{
+				map[string]any{
 					"registry.example.com/eggs:9.8":               "registry.example.com/eggs@sha256:2",
 					"registry.example.com/maps/spam-operator:1.2": "registry.example.com/maps/spam-operator@sha256:1",
 				}))
@@ -177,7 +180,7 @@ exit 1
 
 			resolvedFile = resolvedFileBuffer.Bytes()
 
-			resolveData, _ = json.Marshal(map[string]interface{}{
+			resolveData, _ = json.Marshal(map[string]any{
 				"registry.example.com/eggs:9.8":               "registry.example.com/eggs@sha256:2",
 				"registry.example.com/maps/spam-operator:1.2": "registry.example.com/maps/spam-operator@sha256:1",
 			})
@@ -261,7 +264,7 @@ exit 1
 			extractAnswer, err := os.ReadFile(outputExtract.Name)
 			Expect(err).To(Succeed())
 
-			extractJson := []interface{}{}
+			extractJson := []any{}
 
 			Expect(json.Unmarshal(extractAnswer, &extractJson)).To(Succeed())
 			Expect(extractJson).To(HaveLen(2))
@@ -271,11 +274,11 @@ exit 1
 			resolveAnswer, err := os.ReadFile(outputReplace.Name)
 			Expect(err).To(Succeed())
 
-			resolveJson := map[string]interface{}{}
+			resolveJson := map[string]any{}
 			Expect(json.Unmarshal(resolveAnswer, &resolveJson)).To(Succeed())
 			Expect(resolveJson).To(HaveLen(2))
 			Expect(resolveJson).To(Equal(
-				map[string]interface{}{
+				map[string]any{
 					"registry.example.com/eggs:9.8":               "registry.example.com/eggs@sha256:2",
 					"registry.example.com/maps/spam-operator:1.2": "registry.example.com/maps/spam-operator@sha256:1",
 				}))
@@ -284,7 +287,7 @@ exit 1
 			Expect(err).To(Succeed())
 			Expect(replaceAnswer).To(MatchUnorderedYAML(resolvedFile))
 
-			validYaml := map[string]interface{}{}
+			validYaml := map[string]any{}
 			Expect(yaml.Unmarshal(replaceAnswer, &validYaml)).To(Succeed())
 		})
 	})

--- a/cmd/pinning/pinning_test.go
+++ b/cmd/pinning/pinning_test.go
@@ -36,8 +36,15 @@ var _ = Describe("pinning", func() {
 
 		dir, err := os.MkdirTemp("", "script")
 		Expect(err).To(Succeed())
+		DeferCleanup(func() {
+			Expect(os.RemoveAll(dir)).To(Succeed())
+		})
+
 		manifestDir, err = os.MkdirTemp("", "pinning_test_")
 		Expect(err).To(Succeed())
+		DeferCleanup(func() {
+			Expect(os.RemoveAll(manifestDir)).To(Succeed())
+		})
 		csvFilePath = filepath.Join(manifestDir, "clusterserviceversion.yaml")
 
 		resolverScript := filepath.Join(dir, "resolver.sh")

--- a/internal/utils/error.go
+++ b/internal/utils/error.go
@@ -28,7 +28,7 @@ type errBase struct {
 	err   error
 }
 
-func NewError(cause error, format string, args ...interface{}) error {
+func NewError(cause error, format string, args ...any) error {
 	return errBase{
 		err:   fmt.Errorf(format, args...),
 		cause: cause,

--- a/internal/utils/lens.go
+++ b/internal/utils/lens.go
@@ -28,18 +28,17 @@ func Lens() *lensBuilder {
 func (d *lensBuilder) L(i int) *lensBuilder {
 	d.path = append(d.path, strconv.Itoa(i))
 	d.funcs = append(d.funcs, func(data any) (any, error) {
-		localI := i
 		slice, ok := data.([]any)
 
 		if !ok {
-			return nil, NewError(ErrNotFound, "expected a []any type on step %s path %s", strconv.Itoa(localI), strings.Join(d.path, ","))
+			return nil, NewError(ErrNotFound, "expected a []any type on step %s path %s", strconv.Itoa(i), strings.Join(d.path, ","))
 		}
 
 		if i < 0 || i >= len(slice) {
-			return nil, NewError(ErrNotFound, "not found on step %s path %s", strconv.Itoa(localI), strings.Join(d.path, ","))
+			return nil, NewError(ErrNotFound, "not found on step %s path %s", strconv.Itoa(i), strings.Join(d.path, ","))
 		}
 
-		return slice[localI], nil
+		return slice[i], nil
 	})
 
 	return d
@@ -49,16 +48,15 @@ func (d *lensBuilder) L(i int) *lensBuilder {
 func (d *lensBuilder) M(key string) *lensBuilder {
 	d.path = append(d.path, key)
 	d.funcs = append(d.funcs, func(data any) (any, error) {
-		localKey := key
 		mmap, ok := data.(map[string]any)
 
 		if !ok {
-			return nil, NewError(ErrNotFound, "expected a map[string]any type on step %s path %s", localKey, strings.Join(d.path, ","))
+			return nil, NewError(ErrNotFound, "expected a map[string]any type on step %s path %s", key, strings.Join(d.path, ","))
 		}
 
 		v, ok := mmap[key]
 		if !ok {
-			return nil, NewError(ErrNotFound, "not found on step %s path %s", localKey, strings.Join(d.path, ","))
+			return nil, NewError(ErrNotFound, "not found on step %s path %s", key, strings.Join(d.path, ","))
 		}
 
 		return v, nil
@@ -71,7 +69,6 @@ func (d *lensBuilder) M(key string) *lensBuilder {
 func (d *lensBuilder) Apply(l lens) *lensBuilder {
 	d.path = append(d.path, "*")
 	d.funcs = append(d.funcs, func(data any) (any, error) {
-		localLens := l
 		slice, ok := data.([]any)
 
 		if !ok {
@@ -83,7 +80,7 @@ func (d *lensBuilder) Apply(l lens) *lensBuilder {
 		for i := range slice {
 			data := slice[i]
 
-			result, err := localLens.Lookup(data)
+			result, err := l.Lookup(data)
 
 			if err != nil {
 				continue
@@ -102,11 +99,7 @@ func (d *lensBuilder) Apply(l lens) *lensBuilder {
 // Build finalizes the lens steps and makes it able to return results.
 func (d *lensBuilder) Build() lens {
 	funcs := make([]func(any) (any, error), 0, len(d.funcs))
-
-	for i := range d.funcs {
-		localFunc := d.funcs[i]
-		funcs = append(funcs, localFunc)
-	}
+	funcs = append(funcs, d.funcs...)
 
 	return lens{
 		funcs: funcs,

--- a/internal/utils/lens.go
+++ b/internal/utils/lens.go
@@ -7,19 +7,19 @@ import (
 
 // lensBuilder is used to construct lens
 type lensBuilder struct {
-	funcs []func(interface{}) (interface{}, error)
+	funcs []func(any) (any, error)
 	path  []string
 }
 
-// lens holds a series of functions that helps navigate a map[string]interface{} data structure
+// lens holds a series of functions that helps navigate a map[string]any data structure
 type lens struct {
-	funcs []func(interface{}) (interface{}, error)
+	funcs []func(any) (any, error)
 }
 
 // newLens creates a new lens builder
 func Lens() *lensBuilder {
 	return &lensBuilder{
-		funcs: []func(interface{}) (interface{}, error){},
+		funcs: []func(any) (any, error){},
 		path:  []string{},
 	}
 }
@@ -27,12 +27,12 @@ func Lens() *lensBuilder {
 // L will create a step on a lens to navigate a slice by integer
 func (d *lensBuilder) L(i int) *lensBuilder {
 	d.path = append(d.path, strconv.Itoa(i))
-	d.funcs = append(d.funcs, func(data interface{}) (interface{}, error) {
+	d.funcs = append(d.funcs, func(data any) (any, error) {
 		localI := i
-		slice, ok := data.([]interface{})
+		slice, ok := data.([]any)
 
 		if !ok {
-			return nil, NewError(ErrNotFound, "expected a []interface{} type on step %s path %s", strconv.Itoa(localI), strings.Join(d.path, ","))
+			return nil, NewError(ErrNotFound, "expected a []any type on step %s path %s", strconv.Itoa(localI), strings.Join(d.path, ","))
 		}
 
 		if i < 0 || i >= len(slice) {
@@ -48,12 +48,12 @@ func (d *lensBuilder) L(i int) *lensBuilder {
 // M will create a step on a lens to navigate a map by a key
 func (d *lensBuilder) M(key string) *lensBuilder {
 	d.path = append(d.path, key)
-	d.funcs = append(d.funcs, func(data interface{}) (interface{}, error) {
+	d.funcs = append(d.funcs, func(data any) (any, error) {
 		localKey := key
-		mmap, ok := data.(map[string]interface{})
+		mmap, ok := data.(map[string]any)
 
 		if !ok {
-			return nil, NewError(ErrNotFound, "expected a map[string]interface{} type on step %s path %s", localKey, strings.Join(d.path, ","))
+			return nil, NewError(ErrNotFound, "expected a map[string]any type on step %s path %s", localKey, strings.Join(d.path, ","))
 		}
 
 		v, ok := mmap[key]
@@ -70,15 +70,15 @@ func (d *lensBuilder) M(key string) *lensBuilder {
 // lens to each element.
 func (d *lensBuilder) Apply(l lens) *lensBuilder {
 	d.path = append(d.path, "*")
-	d.funcs = append(d.funcs, func(data interface{}) (interface{}, error) {
+	d.funcs = append(d.funcs, func(data any) (any, error) {
 		localLens := l
-		slice, ok := data.([]interface{})
+		slice, ok := data.([]any)
 
 		if !ok {
-			return nil, NewError(ErrNotFound, "expected a []interface{} type on step * path %s", strings.Join(d.path, ","))
+			return nil, NewError(ErrNotFound, "expected a []any type on step * path %s", strings.Join(d.path, ","))
 		}
 
-		results := make([]interface{}, 0, len(slice))
+		results := make([]any, 0, len(slice))
 
 		for i := range slice {
 			data := slice[i]
@@ -101,7 +101,7 @@ func (d *lensBuilder) Apply(l lens) *lensBuilder {
 
 // Build finalizes the lens steps and makes it able to return results.
 func (d *lensBuilder) Build() lens {
-	funcs := make([]func(interface{}) (interface{}, error), 0, len(d.funcs))
+	funcs := make([]func(any) (any, error), 0, len(d.funcs))
 
 	for i := range d.funcs {
 		localFunc := d.funcs[i]
@@ -114,7 +114,7 @@ func (d *lensBuilder) Build() lens {
 }
 
 // Lookup will run the lens against data, returning a result or error.
-func (l lens) Lookup(data interface{}) (result interface{}, err error) {
+func (l lens) Lookup(data any) (result any, err error) {
 	result = data
 	for _, fun := range l.funcs {
 		result, err = fun(result)
@@ -128,17 +128,17 @@ func (l lens) Lookup(data interface{}) (result interface{}, err error) {
 }
 
 // L is an alias for Lookup that will attempt to map the result of the lookup to a slice.
-func (l lens) L(data interface{}) ([]interface{}, error) {
+func (l lens) L(data any) ([]any, error) {
 	answer, err := l.Lookup(data)
 
 	if err != nil {
 		return nil, err
 	}
 
-	listAnswer, ok := answer.([]interface{})
+	listAnswer, ok := answer.([]any)
 
 	if !ok {
-		return nil, NewError(nil, "expected a []interface{} type")
+		return nil, NewError(nil, "expected a []any type")
 	}
 
 	return listAnswer, nil
@@ -146,33 +146,33 @@ func (l lens) L(data interface{}) ([]interface{}, error) {
 
 // LFunc is an alias for Lookup that will attempt to map the result of the lookup to a slice and wrap
 // the results in a callback.
-func (l lens) LFunc(data interface{}) func() ([]interface{}, error) {
-	return func() ([]interface{}, error) {
+func (l lens) LFunc(data any) func() ([]any, error) {
+	return func() ([]any, error) {
 		return l.L(data)
 	}
 }
 
-// M is an alias for Lookup that will attempt to map the result of the lookup to a map[string]interface{}.
-func (l lens) M(data interface{}) (map[string]interface{}, error) {
+// M is an alias for Lookup that will attempt to map the result of the lookup to a map[string]any.
+func (l lens) M(data any) (map[string]any, error) {
 	answer, err := l.Lookup(data)
 
 	if err != nil {
 		return nil, err
 	}
 
-	mapAnswer, ok := answer.(map[string]interface{})
+	mapAnswer, ok := answer.(map[string]any)
 
 	if !ok {
-		return nil, NewError(nil, "expected a []interface{} type")
+		return nil, NewError(nil, "expected a map[string]any type but got a %T instead", answer)
 	}
 
 	return mapAnswer, nil
 }
 
-// M is an alias for Lookup that will attempt to map the result of the lookup to a map[string]interface{} and wrap
-// the resutls in a callback.
-func (l lens) MFunc(data interface{}) func() (map[string]interface{}, error) {
-	return func() (map[string]interface{}, error) {
+// M is an alias for Lookup that will attempt to map the result of the lookup to a map[string]any and wrap
+// the results in a callback.
+func (l lens) MFunc(data any) func() (map[string]any, error) {
+	return func() (map[string]any, error) {
 		return l.M(data)
 	}
 }

--- a/internal/utils/lens_test.go
+++ b/internal/utils/lens_test.go
@@ -6,15 +6,15 @@ import (
 )
 
 var _ = Describe("lens", func() {
-	var data map[string]interface{}
+	var data map[string]any
 	BeforeEach(func() {
-		data = map[string]interface{}{
+		data = map[string]any{
 			"a": "b",
-			"c": []interface{}{
-				map[string]interface{}{
+			"c": []any{
+				map[string]any{
 					"d": 1,
 				},
-				map[string]interface{}{
+				map[string]any{
 					"d": 2,
 				},
 			},
@@ -63,7 +63,7 @@ var _ = Describe("lens", func() {
 		myLens := Lens().M("c").Apply(Lens().M("d").Build()).Build()
 		answer, err := myLens.L(data)
 		Expect(err).To(Succeed())
-		Expect(answer).To(Equal([]interface{}{1, 2}))
+		Expect(answer).To(Equal([]any{1, 2}))
 
 		myLens = Lens().M("c").Apply(Lens().M("nothere").Build()).Build()
 		answer, err = myLens.L(data)

--- a/internal/utils/vars_test.go
+++ b/internal/utils/vars_test.go
@@ -3,7 +3,6 @@ package utils
 import (
 	"bytes"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -31,11 +30,13 @@ var _ = Describe("Vars", func() {
 		})
 
 		It("should and open a file if a valid filepath", func() {
-			f, err := ioutil.TempFile(os.TempDir(), "file-*.txt")
+			f, err := os.CreateTemp(os.TempDir(), "file-*.txt")
 			Expect(err).To(Succeed())
 			defer os.Remove(f.Name())
+			defer f.Close()
 
-			ioutil.WriteFile(f.Name(), []byte("foo"), 0666)
+			err = os.WriteFile(f.Name(), []byte("foo"), 0666)
+			Expect(err).To(Succeed())
 
 			sut.Name = f.Name()
 

--- a/pkg/imageresolver/script_test.go
+++ b/pkg/imageresolver/script_test.go
@@ -1,7 +1,7 @@
 package imageresolver
 
 import (
-	"io/ioutil"
+	"os"
 	"path/filepath"
 
 	. "github.com/onsi/ginkgo"
@@ -14,17 +14,17 @@ var _ = Describe("script image resolver", func() {
 	var badScript string
 
 	BeforeEach(func() {
-		dir, err := ioutil.TempDir("", "script")
+		dir, err := os.MkdirTemp("", "script")
 		Expect(err).To(Succeed())
 
 		goodScript = filepath.Join(dir, "good.sh")
 		badScript = filepath.Join(dir, "bad.sh")
-		Expect(ioutil.WriteFile(goodScript, []byte(`#!/bin/bash
+		Expect(os.WriteFile(goodScript, []byte(`#!/bin/bash
 echo -n "foo"
 exit 0
 `), 0700)).To(Succeed())
 
-		Expect(ioutil.WriteFile(badScript, []byte(`#!/bin/bash
+		Expect(os.WriteFile(badScript, []byte(`#!/bin/bash
 exit 1
 `), 0700)).To(Succeed())
 	})

--- a/pkg/imageresolver/skopeo.go
+++ b/pkg/imageresolver/skopeo.go
@@ -44,7 +44,7 @@ const (
 	timeout = "300s"
 )
 
-func (skopeo *Skopeo) getSkopeoResults(args ...string) ([]byte, map[string]interface{}, error) {
+func (skopeo *Skopeo) getSkopeoResults(args ...string) ([]byte, map[string]any, error) {
 	baseArgs := []string{"--command-timeout", timeout, "inspect"}
 	name := "skopeo"
 	if skopeo.path != "" {
@@ -57,7 +57,7 @@ func (skopeo *Skopeo) getSkopeoResults(args ...string) ([]byte, map[string]inter
 		return nil, nil, err
 	}
 
-	var skopeoJSON map[string]interface{}
+	var skopeoJSON map[string]any
 
 	err = json.Unmarshal(skopeoRaw, &skopeoJSON)
 	if err != nil {
@@ -85,7 +85,7 @@ func (skopeo *Skopeo) ResolveImageReference(imageReference string) (string, erro
 	retryAttempts := 3
 
 	var skopeoRaw []byte
-	var skopeoJSON map[string]interface{}
+	var skopeoJSON map[string]any
 
 	for i := 0; i < retryAttempts; i++ {
 		rawArgs := append(args, "--raw")

--- a/pkg/imageresolver/skopeo.go
+++ b/pkg/imageresolver/skopeo.go
@@ -87,7 +87,7 @@ func (skopeo *Skopeo) ResolveImageReference(imageReference string) (string, erro
 	var skopeoRaw []byte
 	var skopeoJSON map[string]any
 
-	for i := 0; i < retryAttempts; i++ {
+	for range retryAttempts {
 		rawArgs := append(args, "--raw")
 		log.Println("skopeo inspect raw args are ", rawArgs)
 		skopeoRaw, skopeoJSON, err = skopeo.getSkopeoResults(rawArgs...)

--- a/pkg/pullspec/heuristic.go
+++ b/pkg/pullspec/heuristic.go
@@ -60,13 +60,13 @@ var (
 	full      = regexp.MustCompile(mustExecute(templates, `^{{ template "pullspec" . }}$`, "alnum", alnum, "name", name, "base16", base16))
 )
 
-// mustExecute executes a template, panicing on error
-func mustExecute(templates *template.Template, templ string, data ...interface{}) string {
+// mustExecute executes a template, panicking on error
+func mustExecute(templates *template.Template, templ string, data ...any) string {
 	if len(data)%2 != 0 {
 		panic("data length must be 2")
 	}
 
-	templateData := map[string]interface{}{}
+	templateData := map[string]any{}
 
 	for i := 0; i < len(data); i = i + 2 {
 		key := data[i].(string)
@@ -98,16 +98,22 @@ type Heuristic func(text string) [][]int
 
 // DefaultHeuristic attempts to find all pullspecs in arbitrary structured/unstructured text.
 // Returns a list of (start, end) tuples such that:
-//     text[start:end] == <n-th pullspec in text> for all (start, end)
+//
+//	text[start:end] == <n-th pullspec in text> for all (start, end)
+//
 // The basic idea:
 // - Find continuous sequences of characters that might appear in a pullspec
 //   - That being <alphanumeric> + "/-._@:"
+//
 // - For each such sequence:
 //   - Strip non-alphanumeric characters from both ends
 //   - Match remainder against the pullspec regex
+//
 // Put simply, this heuristic should find anything in the form:
-//     registry/namespace*/repo:tag
-//     registry/namespace*/repo@sha256:digest
+//
+//	registry/namespace*/repo:tag
+//	registry/namespace*/repo@sha256:digest
+//
 // Where registry must contain at least one '.' and all parts follow various
 // restrictions on the format (most typical pullspecs should be caught). Any
 // number of namespaces, including 0, is valid.

--- a/pkg/pullspec/pullspec.go
+++ b/pkg/pullspec/pullspec.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	"io/fs"
@@ -569,7 +570,7 @@ func (csv *OperatorCSV) SetRelatedImages() error {
 	return nil
 }
 
-var knownAnnotationKeys = stringSlice{"containerImage"}
+var knownAnnotationKeys = []string{"containerImage"}
 
 func (csv *OperatorCSV) namedPullSpecs() ([]NamedPullSpec, error) {
 	pullspecs := []NamedPullSpec{}
@@ -789,7 +790,7 @@ func (csv *OperatorCSV) relatedImageEnvPullSpecs() ([]NamedPullSpec, error) {
 	return relatedImageEnvs, nil
 }
 
-func (csv *OperatorCSV) annotationPullSpecs(keyFilter stringSlice) ([]NamedPullSpec, error) {
+func (csv *OperatorCSV) annotationPullSpecs(keyFilter []string) ([]NamedPullSpec, error) {
 	pullSpecs := []NamedPullSpec{}
 
 	annotationObjects, err := csv.findAllAnnotations()
@@ -804,7 +805,7 @@ func (csv *OperatorCSV) annotationPullSpecs(keyFilter stringSlice) ([]NamedPullS
 			key := rKey
 			val := obj[key]
 
-			if keyFilter != nil && !keyFilter.Contains(key) {
+			if keyFilter != nil && !slices.Contains(keyFilter, key) {
 				continue
 			}
 
@@ -818,7 +819,8 @@ func (csv *OperatorCSV) annotationPullSpecs(keyFilter stringSlice) ([]NamedPullS
 		}
 	}
 
-	return namedPullSpecSlice(pullSpecs).Reverse(), nil
+	slices.Reverse(pullSpecs)
+	return pullSpecs, nil
 }
 
 var (
@@ -969,27 +971,6 @@ func (csv *OperatorCSV) findPotentialPullSpecsNotInAnnotations(root map[string]a
 	}
 
 	return nil
-}
-
-type stringSlice []string
-
-func (l stringSlice) Contains(in string) bool {
-	for _, key := range l {
-		if key == in {
-			return true
-		}
-	}
-	return false
-}
-
-type namedPullSpecSlice []NamedPullSpec
-
-func (n namedPullSpecSlice) Reverse() namedPullSpecSlice {
-	for i := 0; i < len(n)/2; i++ {
-		j := len(n) - i - 1
-		n[i], n[j] = n[j], n[i]
-	}
-	return n
 }
 
 func closeFile(f *os.File) {

--- a/pkg/pullspec/pullspec.go
+++ b/pkg/pullspec/pullspec.go
@@ -446,8 +446,7 @@ func (csv *OperatorCSV) GetPullSpecs() ([]*imagename.ImageName, error) {
 	imageList := make([]*imagename.ImageName, 0, len(pullspecs))
 
 	for key := range pullspecs {
-		localKey := key
-		imageList = append(imageList, &localKey)
+		imageList = append(imageList, &key)
 	}
 
 	return imageList, nil

--- a/pkg/pullspec/pullspec.go
+++ b/pkg/pullspec/pullspec.go
@@ -25,14 +25,14 @@ type NamedPullSpec interface {
 	fmt.Stringer
 	Name() string
 	Image() string
-	Data() map[string]interface{}
+	Data() map[string]any
 	SetImage(string)
-	AsYamlObject() map[string]interface{}
+	AsYamlObject() map[string]any
 }
 
 type namedPullSpec struct {
 	imageKey string
-	data     map[string]interface{}
+	data     map[string]any
 }
 
 // Name returns the name of the pull spec data.
@@ -46,7 +46,7 @@ func (named *namedPullSpec) Image() string {
 }
 
 // Data returns the namedPullSpec as a json map
-func (named *namedPullSpec) Data() map[string]interface{} {
+func (named *namedPullSpec) Data() map[string]any {
 	return named.data
 }
 
@@ -56,8 +56,8 @@ func (named *namedPullSpec) SetImage(image string) {
 }
 
 // AsYamlObject returns the pull spec as an object
-func (named *namedPullSpec) AsYamlObject() map[string]interface{} {
-	return map[string]interface{}{
+func (named *namedPullSpec) AsYamlObject() map[string]any {
+	return map[string]any{
 		"name":  named.Name(),
 		"image": named.Image(),
 	}
@@ -74,11 +74,11 @@ func (container *Container) String() string {
 }
 
 // NewContainer returns a container pullspec
-func NewContainer(data interface{}) (*Container, error) {
-	dataMap, ok := data.(map[string]interface{})
+func NewContainer(data any) (*Container, error) {
+	dataMap, ok := data.(map[string]any)
 
 	if !ok {
-		return nil, errors.New("expected map[string]interface{} type")
+		return nil, errors.New("expected map[string]any type")
 	}
 
 	if _, ok := dataMap["image"]; !ok {
@@ -105,11 +105,11 @@ func (container *InitContainer) String() string {
 }
 
 // NewInitContainer returns a new init container pullspec.
-func NewInitContainer(data interface{}) (*InitContainer, error) {
-	dataMap, ok := data.(map[string]interface{})
+func NewInitContainer(data any) (*InitContainer, error) {
+	dataMap, ok := data.(map[string]any)
 
 	if !ok {
-		return nil, errors.New("expected map[string]interface{} type")
+		return nil, errors.New("expected map[string]any type")
 	}
 
 	if _, ok := dataMap["image"]; !ok {
@@ -135,11 +135,11 @@ func (relatedImage *RelatedImage) String() string {
 }
 
 // NewRelatedImage returns a new related image pullspec.
-func NewRelatedImage(data interface{}) (*RelatedImage, error) {
-	dataMap, ok := data.(map[string]interface{})
+func NewRelatedImage(data any) (*RelatedImage, error) {
+	dataMap, ok := data.(map[string]any)
 
 	if !ok {
-		return nil, errors.New("expected map[string]interface{} type")
+		return nil, errors.New("expected map[string]any type")
 	}
 
 	return &RelatedImage{
@@ -167,16 +167,16 @@ func (relatedImageEnv *RelatedImageEnv) Name() string {
 	return strings.TrimSpace(strings.ToLower(text[len("RELATED_IMAGE_"):]))
 }
 
-// AsYamlObject returns the pullspec as a map[string]interface{}.
-func (relatedImageEnv *RelatedImageEnv) AsYamlObject() map[string]interface{} {
-	return map[string]interface{}{
+// AsYamlObject returns the pullspec as a map[string]any.
+func (relatedImageEnv *RelatedImageEnv) AsYamlObject() map[string]any {
+	return map[string]any{
 		"name":  relatedImageEnv.Name(),
 		"image": relatedImageEnv.Image(),
 	}
 }
 
-// NewRelatedImageEnv returns a new related iamge env pullspec.
-func NewRelatedImageEnv(data map[string]interface{}) *RelatedImageEnv {
+// NewRelatedImageEnv returns a new related image env pullspec.
+func NewRelatedImageEnv(data map[string]any) *RelatedImageEnv {
 	return &RelatedImageEnv{
 		namedPullSpec: namedPullSpec{
 			imageKey: "value",
@@ -193,7 +193,7 @@ type Annotation struct {
 }
 
 // NewAnnotation returns a new annotation pullspec.
-func NewAnnotation(data map[string]interface{}, key string, startI, endI int) *Annotation {
+func NewAnnotation(data map[string]any, key string, startI, endI int) *Annotation {
 	return &Annotation{
 		namedPullSpec: namedPullSpec{
 			imageKey: key,
@@ -234,9 +234,9 @@ func (annotation *Annotation) Name() string {
 	return fmt.Sprintf("%s-%s-annotation", image.Repo, tag)
 }
 
-// AsYamlObject returns the annotation pullspec as a map[string]interface{}.
-func (annotation *Annotation) AsYamlObject() map[string]interface{} {
-	return map[string]interface{}{
+// AsYamlObject returns the annotation pullspec as a map[string]any.
+func (annotation *Annotation) AsYamlObject() map[string]any {
+	return map[string]any{
 		"name":  annotation.Name(),
 		"image": annotation.Image(),
 	}
@@ -427,7 +427,7 @@ func (csv *OperatorCSV) HasRelatedImageEnvs() bool {
 
 // GetPullSpecs will return a list of all the images found in via pullspecs.
 func (csv *OperatorCSV) GetPullSpecs() ([]*imagename.ImageName, error) {
-	pullspecs := make(map[imagename.ImageName]interface{})
+	pullspecs := make(map[imagename.ImageName]any)
 
 	namedList, err := csv.namedPullSpecs()
 
@@ -549,7 +549,7 @@ func (csv *OperatorCSV) SetRelatedImages() error {
 		return fmt.Errorf("%s - Found conflicts when setting relatedImages:\n%s", csv.path, strings.Join(conflicts, "\n"))
 	}
 
-	relatedImages := []map[string]interface{}{}
+	relatedImages := []map[string]any{}
 
 	for _, p := range byName {
 		log.Printf("%s - Set relateImage %s (from %s): %s\n", csv.path, p.Name(), p.String(), p.Image())
@@ -558,12 +558,12 @@ func (csv *OperatorCSV) SetRelatedImages() error {
 
 	spec, ok := csv.data.Object["spec"]
 	if !ok {
-		spec = map[string]interface{}{
+		spec = map[string]any{
 			"relatedImages": relatedImages,
 		}
 		csv.data.Object["spec"] = spec
 	} else {
-		spec.(map[string]interface{})["relatedImages"] = relatedImages
+		spec.(map[string]any)["relatedImages"] = relatedImages
 	}
 
 	return nil
@@ -656,7 +656,7 @@ func (csv *OperatorCSV) relatedImageEnvPullspecs() ([][]int, error) {
 
 var deploymentLens = utils.Lens().M("spec").M("install").M("spec").M("deployments").Build()
 
-func (csv *OperatorCSV) deployments() ([]interface{}, error) {
+func (csv *OperatorCSV) deployments() ([]any, error) {
 	return deploymentLens.L(csv.data.Object)
 }
 
@@ -760,13 +760,13 @@ func (csv *OperatorCSV) relatedImageEnvPullSpecs() ([]NamedPullSpec, error) {
 			continue
 		}
 
-		envMaps, ok := env.([]interface{})
+		envMaps, ok := env.([]any)
 		if !ok {
 			return nil, errors.New("expected type slice")
 		}
 
 		for j := range envMaps {
-			envMap, ok := envMaps[j].(map[string]interface{})
+			envMap, ok := envMaps[j].(map[string]any)
 
 			if !ok {
 				return nil, errors.New("expected type map")
@@ -830,21 +830,21 @@ var (
 				Build()
 )
 
-func (csv *OperatorCSV) findAllAnnotations() ([]map[string]interface{}, error) {
-	findAnnotationMaps := []func() (map[string]interface{}, error){
+func (csv *OperatorCSV) findAllAnnotations() ([]map[string]any, error) {
+	findAnnotationMaps := []func() (map[string]any, error){
 		csvAnnotations.MFunc(csv.data.Object),
 	}
 
-	findAnnotationSlices := []func() ([]interface{}, error){
+	findAnnotationSlices := []func() ([]any, error){
 		deploymentsAnnotations.LFunc(csv.data.Object),
-		func() ([]interface{}, error) {
-			results := []interface{}{}
+		func() ([]any, error) {
+			results := []any{}
 			err := csv.findRandomCSVAnnotations(csv.data.Object, &results, false)
 			return results, err
 		},
 	}
 
-	annotations := []map[string]interface{}{}
+	annotations := []map[string]any{}
 
 	for _, findAnnotation := range findAnnotationMaps {
 		result, err := findAnnotation()
@@ -870,7 +870,7 @@ func (csv *OperatorCSV) findAllAnnotations() ([]map[string]interface{}, error) {
 		}
 
 		for _, result := range results {
-			annotationResult := result.(map[string]interface{})
+			annotationResult := result.(map[string]any)
 			annotations = append(annotations, annotationResult)
 		}
 	}
@@ -880,7 +880,7 @@ func (csv *OperatorCSV) findAllAnnotations() ([]map[string]interface{}, error) {
 
 var annotations = utils.Lens().M("metadata").M("annotations").Build()
 
-func (csv *OperatorCSV) findRandomCSVAnnotations(root map[string]interface{}, results *[]interface{}, underMetadata bool) error {
+func (csv *OperatorCSV) findRandomCSVAnnotations(root map[string]any, results *[]any, underMetadata bool) error {
 	annos, err := annotations.M(root)
 
 	if err != nil && !errors.Is(err, utils.ErrNotFound) {
@@ -902,10 +902,10 @@ func (csv *OperatorCSV) findRandomCSVAnnotations(root map[string]interface{}, re
 			isUnderMetadata = true
 		}
 
-		if slicev, ok := root[key].([]interface{}); ok {
+		if slicev, ok := root[key].([]any); ok {
 
 			for i := range slicev {
-				if datav, ok := slicev[i].(map[string]interface{}); ok {
+				if datav, ok := slicev[i].(map[string]any); ok {
 					err := csv.findRandomCSVAnnotations(datav, results, isUnderMetadata)
 
 					if err != nil {
@@ -915,7 +915,7 @@ func (csv *OperatorCSV) findRandomCSVAnnotations(root map[string]interface{}, re
 			}
 		}
 
-		if datav, ok := root[key].(map[string]interface{}); ok {
+		if datav, ok := root[key].(map[string]any); ok {
 			err := csv.findRandomCSVAnnotations(datav, results, isUnderMetadata)
 
 			if err != nil {
@@ -927,7 +927,7 @@ func (csv *OperatorCSV) findRandomCSVAnnotations(root map[string]interface{}, re
 	return nil
 }
 
-func (csv *OperatorCSV) findPotentialPullSpecsNotInAnnotations(root map[string]interface{}, specs *[]NamedPullSpec) error {
+func (csv *OperatorCSV) findPotentialPullSpecsNotInAnnotations(root map[string]any, specs *[]NamedPullSpec) error {
 	for rKey := range root {
 		key := rKey
 		val := root[key]
@@ -946,10 +946,10 @@ func (csv *OperatorCSV) findPotentialPullSpecsNotInAnnotations(root map[string]i
 			continue
 		}
 
-		if slicev, ok := root[key].([]interface{}); ok {
+		if slicev, ok := root[key].([]any); ok {
 
 			for i := range slicev {
-				if datav, ok := slicev[i].(map[string]interface{}); ok {
+				if datav, ok := slicev[i].(map[string]any); ok {
 					err := csv.findPotentialPullSpecsNotInAnnotations(datav, specs)
 
 					if err != nil {
@@ -959,7 +959,7 @@ func (csv *OperatorCSV) findPotentialPullSpecsNotInAnnotations(root map[string]i
 			}
 		}
 
-		if datav, ok := root[key].(map[string]interface{}); ok {
+		if datav, ok := root[key].(map[string]any); ok {
 			err := csv.findPotentialPullSpecsNotInAnnotations(datav, specs)
 
 			if err != nil {


### PR DESCRIPTION
It may be easier to review each commit in this PR individually. This PR covers:
- Prefer `any` instead of `interface{}` (more readable/intentional)
- Simplify loop syntax and remove unneeded loop-local variables (behavior changed in Go 1.22 to make this unnecessary)
- Use the built-in `slices` library to remove custom shim types that provide a custom `Contains` implementation
- Replace usage of `io/ioutil` package with modern equivalents