### PR TITLE
Migrate deprecated gopkg.in/yaml.v3 to go.yaml.in/yaml/v3

### DIFF
--- a/cmd/pinning/pinning_test.go
+++ b/cmd/pinning/pinning_test.go
@@ -12,13 +12,13 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/operator-framework/operator-manifest-tools/internal/utils"
 	"github.com/operator-framework/operator-manifest-tools/pkg/imageresolver"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 var _ = Describe("pinning", func() {
 	var (
 		csvOriginal *template.Template
-		//relatedImage,
+		// relatedImage,
 		resolved                               *template.Template
 		manifestDir, csvFilePath               string
 		eggsImageReference, spamImageReference string
@@ -145,7 +145,8 @@ exit 1
 				map[string]any{
 					"registry.example.com/eggs:9.8":               "registry.example.com/eggs@sha256:2",
 					"registry.example.com/maps/spam-operator:1.2": "registry.example.com/maps/spam-operator@sha256:1",
-				}))
+				},
+			))
 		})
 	})
 
@@ -287,7 +288,8 @@ exit 1
 				map[string]any{
 					"registry.example.com/eggs:9.8":               "registry.example.com/eggs@sha256:2",
 					"registry.example.com/maps/spam-operator:1.2": "registry.example.com/maps/spam-operator@sha256:1",
-				}))
+				},
+			))
 
 			replaceAnswer, err := os.ReadFile(csvFilePath)
 			Expect(err).To(Succeed())
@@ -297,7 +299,6 @@ exit 1
 			Expect(yaml.Unmarshal(replaceAnswer, &validYaml)).To(Succeed())
 		})
 	})
-
 })
 
 const CSV_TEMPLATE = `apiVersion: operators.coreos.com/v1alpha1

--- a/cmd/pinning/pinning_test.go
+++ b/cmd/pinning/pinning_test.go
@@ -18,7 +18,7 @@ import (
 var _ = Describe("pinning", func() {
 	var (
 		csvOriginal *template.Template
-		// relatedImage,
+		//relatedImage,
 		resolved                               *template.Template
 		manifestDir, csvFilePath               string
 		eggsImageReference, spamImageReference string
@@ -145,8 +145,7 @@ exit 1
 				map[string]any{
 					"registry.example.com/eggs:9.8":               "registry.example.com/eggs@sha256:2",
 					"registry.example.com/maps/spam-operator:1.2": "registry.example.com/maps/spam-operator@sha256:1",
-				},
-			))
+				}))
 		})
 	})
 
@@ -288,8 +287,7 @@ exit 1
 				map[string]any{
 					"registry.example.com/eggs:9.8":               "registry.example.com/eggs@sha256:2",
 					"registry.example.com/maps/spam-operator:1.2": "registry.example.com/maps/spam-operator@sha256:1",
-				},
-			))
+				}))
 
 			replaceAnswer, err := os.ReadFile(csvFilePath)
 			Expect(err).To(Succeed())
@@ -299,6 +297,7 @@ exit 1
 			Expect(yaml.Unmarshal(replaceAnswer, &validYaml)).To(Succeed())
 		})
 	})
+
 })
 
 const CSV_TEMPLATE = `apiVersion: operators.coreos.com/v1alpha1

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/onsi/gomega v1.42.1
 	github.com/spf13/cobra v1.10.2
 	github.com/stretchr/testify v1.11.1
-	gopkg.in/yaml.v3 v3.0.1
+	go.yaml.in/yaml/v3 v3.0.4
 	k8s.io/apimachinery v0.36.2
 )
 
@@ -40,7 +40,6 @@ require (
 	github.com/stretchr/objx v0.5.2 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
 	go.yaml.in/yaml/v2 v2.4.3 // indirect
-	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/mod v0.37.0 // indirect
 	golang.org/x/net v0.56.0 // indirect
 	golang.org/x/sync v0.21.0 // indirect
@@ -49,6 +48,7 @@ require (
 	golang.org/x/tools v0.46.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 	gotest.tools/v3 v3.5.2 // indirect
 	k8s.io/klog/v2 v2.140.0 // indirect
 	k8s.io/kube-openapi v0.0.0-20260317180543-43fb72c5454a // indirect

--- a/pkg/pullspec/pullspec.go
+++ b/pkg/pullspec/pullspec.go
@@ -5,17 +5,16 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"log"
 	"os"
 	"path/filepath"
 	"slices"
 	"strings"
 
-	"io/fs"
-
 	"github.com/operator-framework/operator-manifest-tools/internal/utils"
 	"github.com/operator-framework/operator-manifest-tools/pkg/imagename"
-	yamlv3 "gopkg.in/yaml.v3"
+	yamlv3 "go.yaml.in/yaml/v3"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/serializer/yaml"
 )
@@ -272,14 +271,11 @@ const (
 	operatorCsvKind = "ClusterServiceVersion"
 )
 
-var ()
-
 // FromDirectory creates a NewOperatorCSV from the directory path provided.
 func FromDirectory(path string, pullSpecHeuristic Heuristic) ([]*OperatorCSV, error) {
 	operatorCSVs := []*OperatorCSV{}
 
 	stat, err := os.Stat(path)
-
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil, utils.NewErrIsNotDirectoryOrDoesNotExist(path)
@@ -322,7 +318,6 @@ func FromDirectory(path string, pullSpecHeuristic Heuristic) ([]*OperatorCSV, er
 		operatorCSVs = append(operatorCSVs, csv)
 		return nil
 	})
-
 	if err != nil {
 		log.Printf("failure walking the directory: %+v \n", err)
 		return nil, err
@@ -349,7 +344,6 @@ func NewOperatorCSVFromFile(
 	data := &unstructured.Unstructured{}
 
 	fileData, err := os.ReadFile(path)
-
 	if err != nil {
 		return nil, err
 	}
@@ -357,13 +351,11 @@ func NewOperatorCSVFromFile(
 	// decode YAML into unstructured.Unstructured
 	dec := yaml.NewDecodingSerializer(unstructured.UnstructuredJSONScheme)
 	_, _, err = dec.Decode(fileData, nil, data)
-
 	if err != nil {
 		return nil, err
 	}
 
 	csv, err := NewOperatorCSV(path, data, pullSpecHeuristic)
-
 	if err != nil {
 		return nil, err
 	}
@@ -400,13 +392,11 @@ func (csv *OperatorCSV) Dump(writer io.Writer) error {
 	}
 
 	b, err := csv.ToYaml()
-
 	if err != nil {
 		return err
 	}
 
 	_, err = writer.Write(b)
-
 	if err != nil {
 		return err
 	}
@@ -431,7 +421,6 @@ func (csv *OperatorCSV) GetPullSpecs() ([]*imagename.ImageName, error) {
 	pullspecs := make(map[imagename.ImageName]any)
 
 	namedList, err := csv.namedPullSpecs()
-
 	if err != nil {
 		return nil, err
 	}
@@ -475,20 +464,17 @@ func (csv *OperatorCSV) ReplacePullSpecs(replacement map[imagename.ImageName]ima
 // ReplacePullSpecsEverywhere will replace image values in each pullspec throughout the entire OperatorCSV.
 func (csv *OperatorCSV) ReplacePullSpecsEverywhere(replacement map[imagename.ImageName]imagename.ImageName) error {
 	err := csv.ReplacePullSpecs(replacement)
-
 	if err != nil {
 		return err
 	}
 
 	pullspecs := []NamedPullSpec{}
 	annotationPullSpecs, err := csv.annotationPullSpecs(knownAnnotationKeys)
-
 	if err != nil {
 		return err
 	}
 
 	guessedAnnotationPullSpecs, err := csv.annotationPullSpecs(nil)
-
 	if err != nil {
 		return err
 	}
@@ -497,7 +483,6 @@ func (csv *OperatorCSV) ReplacePullSpecsEverywhere(replacement map[imagename.Ima
 	pullspecs = append(pullspecs, guessedAnnotationPullSpecs...)
 
 	err = csv.findPotentialPullSpecsNotInAnnotations(csv.data.Object, &pullspecs)
-
 	if err != nil {
 		return err
 	}
@@ -518,7 +503,6 @@ func (csv *OperatorCSV) ReplacePullSpecsEverywhere(replacement map[imagename.Ima
 // SetRelatedImages will set the related images fields based on the CSV pullspecs discovered.
 func (csv *OperatorCSV) SetRelatedImages() error {
 	namedPullspecs, err := csv.namedPullSpecs()
-
 	if err != nil {
 		return err
 	}
@@ -575,37 +559,31 @@ func (csv *OperatorCSV) namedPullSpecs() ([]NamedPullSpec, error) {
 	pullspecs := []NamedPullSpec{}
 
 	relatedImages, err := csv.relatedImagePullSpecs()
-
 	if err != nil {
 		return pullspecs, err
 	}
 
 	containers, err := csv.containerPullSpecs()
-
 	if err != nil {
 		return pullspecs, err
 	}
 
 	initContainers, err := csv.initContainerPullSpecs()
-
 	if err != nil {
 		return pullspecs, err
 	}
 
 	relatedImageEnvPullSpecs, err := csv.relatedImageEnvPullSpecs()
-
 	if err != nil {
 		return pullspecs, err
 	}
 
 	annotationPullSpecs, err := csv.annotationPullSpecs(knownAnnotationKeys)
-
 	if err != nil {
 		return pullspecs, err
 	}
 
 	guessedAnnotationPullSpecs, err := csv.annotationPullSpecs(nil)
-
 	if err != nil {
 		return pullspecs, err
 	}
@@ -624,7 +602,6 @@ var relatedImagesLens = utils.Lens().M("spec").M("relatedImages").Build()
 
 func (csv *OperatorCSV) relatedImagePullSpecs() ([]NamedPullSpec, error) {
 	lookupResultSlice, err := relatedImagesLens.L(csv.data.Object)
-
 	if err != nil {
 		if errors.Is(err, utils.ErrNotFound) {
 			return []NamedPullSpec{}, nil
@@ -639,7 +616,6 @@ func (csv *OperatorCSV) relatedImagePullSpecs() ([]NamedPullSpec, error) {
 		data := lookupResultSlice[i]
 
 		pullspec, err := NewRelatedImage(data)
-
 		if err != nil {
 			return nil, err
 		}
@@ -664,7 +640,6 @@ var initContainerLens = utils.Lens().M("spec").M("template").M("spec").M("initCo
 
 func (csv *OperatorCSV) initContainerPullSpecs() ([]NamedPullSpec, error) {
 	deployments, err := csv.deployments()
-
 	if err != nil {
 		return nil, err
 	}
@@ -700,7 +675,6 @@ var containerLens = utils.Lens().M("spec").M("template").M("spec").M("containers
 
 func (csv *OperatorCSV) containerPullSpecs() ([]NamedPullSpec, error) {
 	deployments, err := csv.deployments()
-
 	if err != nil {
 		return nil, err
 	}
@@ -709,7 +683,6 @@ func (csv *OperatorCSV) containerPullSpecs() ([]NamedPullSpec, error) {
 
 	for i := range deployments {
 		lookupResultSlice, err := containerLens.L(deployments[i])
-
 		if err != nil {
 			if errors.Is(err, utils.ErrNotFound) {
 				continue
@@ -722,7 +695,6 @@ func (csv *OperatorCSV) containerPullSpecs() ([]NamedPullSpec, error) {
 			data := lookupResultSlice[i]
 
 			pullspec, err := NewContainer(data)
-
 			if err != nil {
 				return nil, err
 			}
@@ -736,13 +708,11 @@ func (csv *OperatorCSV) containerPullSpecs() ([]NamedPullSpec, error) {
 
 func (csv *OperatorCSV) relatedImageEnvPullSpecs() ([]NamedPullSpec, error) {
 	containers, err := csv.containerPullSpecs()
-
 	if err != nil {
 		return nil, err
 	}
 
 	initContainers, err := csv.initContainerPullSpecs()
-
 	if err != nil {
 		return nil, err
 	}
@@ -793,7 +763,6 @@ func (csv *OperatorCSV) annotationPullSpecs(keyFilter []string) ([]NamedPullSpec
 	pullSpecs := []NamedPullSpec{}
 
 	annotationObjects, err := csv.findAllAnnotations()
-
 	if err != nil {
 		return nil, err
 	}
@@ -849,7 +818,6 @@ func (csv *OperatorCSV) findAllAnnotations() ([]map[string]any, error) {
 
 	for _, findAnnotation := range findAnnotationMaps {
 		result, err := findAnnotation()
-
 		if err != nil {
 			if errors.Is(err, utils.ErrNotFound) {
 				continue
@@ -862,7 +830,6 @@ func (csv *OperatorCSV) findAllAnnotations() ([]map[string]any, error) {
 
 	for _, findAnnotation := range findAnnotationSlices {
 		results, err := findAnnotation()
-
 		if err != nil {
 			if errors.Is(err, utils.ErrNotFound) {
 				continue
@@ -904,11 +871,9 @@ func (csv *OperatorCSV) findRandomCSVAnnotations(root map[string]any, results *[
 		}
 
 		if slicev, ok := root[key].([]any); ok {
-
 			for i := range slicev {
 				if datav, ok := slicev[i].(map[string]any); ok {
 					err := csv.findRandomCSVAnnotations(datav, results, isUnderMetadata)
-
 					if err != nil {
 						return err
 					}
@@ -918,7 +883,6 @@ func (csv *OperatorCSV) findRandomCSVAnnotations(root map[string]any, results *[
 
 		if datav, ok := root[key].(map[string]any); ok {
 			err := csv.findRandomCSVAnnotations(datav, results, isUnderMetadata)
-
 			if err != nil {
 				return err
 			}
@@ -948,11 +912,9 @@ func (csv *OperatorCSV) findPotentialPullSpecsNotInAnnotations(root map[string]a
 		}
 
 		if slicev, ok := root[key].([]any); ok {
-
 			for i := range slicev {
 				if datav, ok := slicev[i].(map[string]any); ok {
 					err := csv.findPotentialPullSpecsNotInAnnotations(datav, specs)
-
 					if err != nil {
 						return err
 					}
@@ -962,7 +924,6 @@ func (csv *OperatorCSV) findPotentialPullSpecsNotInAnnotations(root map[string]a
 
 		if datav, ok := root[key].(map[string]any); ok {
 			err := csv.findPotentialPullSpecsNotInAnnotations(datav, specs)
-
 			if err != nil {
 				return err
 			}

--- a/pkg/pullspec/pullspec.go
+++ b/pkg/pullspec/pullspec.go
@@ -5,12 +5,13 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/fs"
 	"log"
 	"os"
 	"path/filepath"
 	"slices"
 	"strings"
+
+	"io/fs"
 
 	"github.com/operator-framework/operator-manifest-tools/internal/utils"
 	"github.com/operator-framework/operator-manifest-tools/pkg/imagename"
@@ -271,11 +272,14 @@ const (
 	operatorCsvKind = "ClusterServiceVersion"
 )
 
+var ()
+
 // FromDirectory creates a NewOperatorCSV from the directory path provided.
 func FromDirectory(path string, pullSpecHeuristic Heuristic) ([]*OperatorCSV, error) {
 	operatorCSVs := []*OperatorCSV{}
 
 	stat, err := os.Stat(path)
+
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil, utils.NewErrIsNotDirectoryOrDoesNotExist(path)
@@ -318,6 +322,7 @@ func FromDirectory(path string, pullSpecHeuristic Heuristic) ([]*OperatorCSV, er
 		operatorCSVs = append(operatorCSVs, csv)
 		return nil
 	})
+
 	if err != nil {
 		log.Printf("failure walking the directory: %+v \n", err)
 		return nil, err
@@ -344,6 +349,7 @@ func NewOperatorCSVFromFile(
 	data := &unstructured.Unstructured{}
 
 	fileData, err := os.ReadFile(path)
+
 	if err != nil {
 		return nil, err
 	}
@@ -351,11 +357,13 @@ func NewOperatorCSVFromFile(
 	// decode YAML into unstructured.Unstructured
 	dec := yaml.NewDecodingSerializer(unstructured.UnstructuredJSONScheme)
 	_, _, err = dec.Decode(fileData, nil, data)
+
 	if err != nil {
 		return nil, err
 	}
 
 	csv, err := NewOperatorCSV(path, data, pullSpecHeuristic)
+
 	if err != nil {
 		return nil, err
 	}
@@ -392,11 +400,13 @@ func (csv *OperatorCSV) Dump(writer io.Writer) error {
 	}
 
 	b, err := csv.ToYaml()
+
 	if err != nil {
 		return err
 	}
 
 	_, err = writer.Write(b)
+
 	if err != nil {
 		return err
 	}
@@ -421,6 +431,7 @@ func (csv *OperatorCSV) GetPullSpecs() ([]*imagename.ImageName, error) {
 	pullspecs := make(map[imagename.ImageName]any)
 
 	namedList, err := csv.namedPullSpecs()
+
 	if err != nil {
 		return nil, err
 	}
@@ -464,17 +475,20 @@ func (csv *OperatorCSV) ReplacePullSpecs(replacement map[imagename.ImageName]ima
 // ReplacePullSpecsEverywhere will replace image values in each pullspec throughout the entire OperatorCSV.
 func (csv *OperatorCSV) ReplacePullSpecsEverywhere(replacement map[imagename.ImageName]imagename.ImageName) error {
 	err := csv.ReplacePullSpecs(replacement)
+
 	if err != nil {
 		return err
 	}
 
 	pullspecs := []NamedPullSpec{}
 	annotationPullSpecs, err := csv.annotationPullSpecs(knownAnnotationKeys)
+
 	if err != nil {
 		return err
 	}
 
 	guessedAnnotationPullSpecs, err := csv.annotationPullSpecs(nil)
+
 	if err != nil {
 		return err
 	}
@@ -483,6 +497,7 @@ func (csv *OperatorCSV) ReplacePullSpecsEverywhere(replacement map[imagename.Ima
 	pullspecs = append(pullspecs, guessedAnnotationPullSpecs...)
 
 	err = csv.findPotentialPullSpecsNotInAnnotations(csv.data.Object, &pullspecs)
+
 	if err != nil {
 		return err
 	}
@@ -503,6 +518,7 @@ func (csv *OperatorCSV) ReplacePullSpecsEverywhere(replacement map[imagename.Ima
 // SetRelatedImages will set the related images fields based on the CSV pullspecs discovered.
 func (csv *OperatorCSV) SetRelatedImages() error {
 	namedPullspecs, err := csv.namedPullSpecs()
+
 	if err != nil {
 		return err
 	}
@@ -559,31 +575,37 @@ func (csv *OperatorCSV) namedPullSpecs() ([]NamedPullSpec, error) {
 	pullspecs := []NamedPullSpec{}
 
 	relatedImages, err := csv.relatedImagePullSpecs()
+
 	if err != nil {
 		return pullspecs, err
 	}
 
 	containers, err := csv.containerPullSpecs()
+
 	if err != nil {
 		return pullspecs, err
 	}
 
 	initContainers, err := csv.initContainerPullSpecs()
+
 	if err != nil {
 		return pullspecs, err
 	}
 
 	relatedImageEnvPullSpecs, err := csv.relatedImageEnvPullSpecs()
+
 	if err != nil {
 		return pullspecs, err
 	}
 
 	annotationPullSpecs, err := csv.annotationPullSpecs(knownAnnotationKeys)
+
 	if err != nil {
 		return pullspecs, err
 	}
 
 	guessedAnnotationPullSpecs, err := csv.annotationPullSpecs(nil)
+
 	if err != nil {
 		return pullspecs, err
 	}
@@ -602,6 +624,7 @@ var relatedImagesLens = utils.Lens().M("spec").M("relatedImages").Build()
 
 func (csv *OperatorCSV) relatedImagePullSpecs() ([]NamedPullSpec, error) {
 	lookupResultSlice, err := relatedImagesLens.L(csv.data.Object)
+
 	if err != nil {
 		if errors.Is(err, utils.ErrNotFound) {
 			return []NamedPullSpec{}, nil
@@ -616,6 +639,7 @@ func (csv *OperatorCSV) relatedImagePullSpecs() ([]NamedPullSpec, error) {
 		data := lookupResultSlice[i]
 
 		pullspec, err := NewRelatedImage(data)
+
 		if err != nil {
 			return nil, err
 		}
@@ -640,6 +664,7 @@ var initContainerLens = utils.Lens().M("spec").M("template").M("spec").M("initCo
 
 func (csv *OperatorCSV) initContainerPullSpecs() ([]NamedPullSpec, error) {
 	deployments, err := csv.deployments()
+
 	if err != nil {
 		return nil, err
 	}
@@ -675,6 +700,7 @@ var containerLens = utils.Lens().M("spec").M("template").M("spec").M("containers
 
 func (csv *OperatorCSV) containerPullSpecs() ([]NamedPullSpec, error) {
 	deployments, err := csv.deployments()
+
 	if err != nil {
 		return nil, err
 	}
@@ -683,6 +709,7 @@ func (csv *OperatorCSV) containerPullSpecs() ([]NamedPullSpec, error) {
 
 	for i := range deployments {
 		lookupResultSlice, err := containerLens.L(deployments[i])
+
 		if err != nil {
 			if errors.Is(err, utils.ErrNotFound) {
 				continue
@@ -695,6 +722,7 @@ func (csv *OperatorCSV) containerPullSpecs() ([]NamedPullSpec, error) {
 			data := lookupResultSlice[i]
 
 			pullspec, err := NewContainer(data)
+
 			if err != nil {
 				return nil, err
 			}
@@ -708,11 +736,13 @@ func (csv *OperatorCSV) containerPullSpecs() ([]NamedPullSpec, error) {
 
 func (csv *OperatorCSV) relatedImageEnvPullSpecs() ([]NamedPullSpec, error) {
 	containers, err := csv.containerPullSpecs()
+
 	if err != nil {
 		return nil, err
 	}
 
 	initContainers, err := csv.initContainerPullSpecs()
+
 	if err != nil {
 		return nil, err
 	}
@@ -763,6 +793,7 @@ func (csv *OperatorCSV) annotationPullSpecs(keyFilter []string) ([]NamedPullSpec
 	pullSpecs := []NamedPullSpec{}
 
 	annotationObjects, err := csv.findAllAnnotations()
+
 	if err != nil {
 		return nil, err
 	}
@@ -818,6 +849,7 @@ func (csv *OperatorCSV) findAllAnnotations() ([]map[string]any, error) {
 
 	for _, findAnnotation := range findAnnotationMaps {
 		result, err := findAnnotation()
+
 		if err != nil {
 			if errors.Is(err, utils.ErrNotFound) {
 				continue
@@ -830,6 +862,7 @@ func (csv *OperatorCSV) findAllAnnotations() ([]map[string]any, error) {
 
 	for _, findAnnotation := range findAnnotationSlices {
 		results, err := findAnnotation()
+
 		if err != nil {
 			if errors.Is(err, utils.ErrNotFound) {
 				continue
@@ -871,9 +904,11 @@ func (csv *OperatorCSV) findRandomCSVAnnotations(root map[string]any, results *[
 		}
 
 		if slicev, ok := root[key].([]any); ok {
+
 			for i := range slicev {
 				if datav, ok := slicev[i].(map[string]any); ok {
 					err := csv.findRandomCSVAnnotations(datav, results, isUnderMetadata)
+
 					if err != nil {
 						return err
 					}
@@ -883,6 +918,7 @@ func (csv *OperatorCSV) findRandomCSVAnnotations(root map[string]any, results *[
 
 		if datav, ok := root[key].(map[string]any); ok {
 			err := csv.findRandomCSVAnnotations(datav, results, isUnderMetadata)
+
 			if err != nil {
 				return err
 			}
@@ -912,9 +948,11 @@ func (csv *OperatorCSV) findPotentialPullSpecsNotInAnnotations(root map[string]a
 		}
 
 		if slicev, ok := root[key].([]any); ok {
+
 			for i := range slicev {
 				if datav, ok := slicev[i].(map[string]any); ok {
 					err := csv.findPotentialPullSpecsNotInAnnotations(datav, specs)
+
 					if err != nil {
 						return err
 					}
@@ -924,6 +962,7 @@ func (csv *OperatorCSV) findPotentialPullSpecsNotInAnnotations(root map[string]a
 
 		if datav, ok := root[key].(map[string]any); ok {
 			err := csv.findPotentialPullSpecsNotInAnnotations(datav, specs)
+
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
Description of the change:
Migrate deprecated gopkg.in/yaml.v3 to go.yaml.in/yaml/v3

The gopkg.in domain is deprecated and the yaml project has moved to go.yaml.in.
This ensures continued updates and security patches.

Reference: https://github.com/yaml/go-yaml