### PR TITLE
Update GitHub Actions in go and integration workflow

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -2,35 +2,35 @@ name: Go
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
   pull_request:
-    branches: [ main ]
+    branches: [main]
 
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
 
-    - name: Set up Go
-      uses: actions/setup-go@v4
-      with:
-        go-version-file: go.mod
+      - name: Set up Go
+        uses: actions/setup-go@v7
+        with:
+          go-version-file: go.mod
 
-    - name: Tidy
-      run: make tidy
+      - name: Tidy
+        run: make tidy
 
-    - name: Vet
-      run: make vet
+      - name: Vet
+        run: make vet
 
-    - name: Format
-      run: make fmt
+      - name: Format
+        run: make fmt
 
-    - name: Run golangci linting checks
-      run: make lint
+      - name: Run golangci linting checks
+        run: make lint
 
-    - name: Build
-      run: go build -v ./...
+      - name: Build
+        run: go build -v ./...
 
-    - name: Test
-      run: make test
+      - name: Test
+        run: make test

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -10,13 +10,13 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
       - name: Set up Gos
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v7
         with:
           go-version-file: go.mod
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v7
         with:
           python-version: 3.9
       - name: Install tox


### PR DESCRIPTION
Updates the GitHub Actions action versions in the Go and Integration Test workflow files to their latest major versions and fixed minor YAML formatting issues.

- **.github/workflows/go.yml**
  - Updated `actions/checkout` to `v7`
  - Updated `actions/setup-go` to `v7`
- **.github/workflows/integration.yml**
  - Updated `actions/checkout` to `v7`
  - Updated `actions/setup-go` to `v7`
  - Updated `actions/setup-python` to `v7`